### PR TITLE
add extraArgs options to clustermesh-apiserver in helm chart

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -165,6 +165,10 @@
      - Clustermesh API server etcd image.
      - object
      - ``{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/coreos/etcd","tag":"v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3"}``
+   * - clustermesh.apiserver.extraArgs
+     - Additional clustermesh-apiserver arguments.
+     - list
+     - ``[]``
    * - clustermesh.apiserver.extraEnv
      - Additional clustermesh-apiserver environment variables.
      - list

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -112,6 +112,9 @@ spec:
         - --cluster-id=$(CLUSTER_ID)
         - --kvstore-opt
         - etcd.config=/var/lib/cilium/etcd-config.yaml
+        {{- with .Values.clustermesh.apiserver.extraArgs }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
         env:
         - name: CLUSTER_NAME
           valueFrom:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1940,6 +1940,9 @@ clustermesh:
     # -- Number of replicas run for the clustermesh-apiserver deployment.
     replicas: 1
 
+    # -- Additional clustermesh-apiserver arguments.
+    extraArgs: []
+
     # -- Additional clustermesh-apiserver environment variables.
     extraEnv: []
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1937,6 +1937,9 @@ clustermesh:
     # -- Number of replicas run for the clustermesh-apiserver deployment.
     replicas: 1
 
+    # -- Additional clustermesh-apiserver arguments.
+    extraArgs: []
+
     # -- Additional clustermesh-apiserver environment variables.
     extraEnv: []
 


### PR DESCRIPTION
Adds extraArgs to cilium helm chart which allows us to provide a qps config option. These changes are being upstreamed here: https://github.com/cilium/cilium/pull/25693

I don't believe they will be backported so we will have to track a patched version of the helm chart for a bit. We may need to make additional changes here to the emptyDir volume type but will ship that in a separate pr if we need to.
